### PR TITLE
Update docs pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-hacker

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <title data-ng-bind="title">OWASP Threat Dragon Docs</title>
@@ -18,9 +18,9 @@
     
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link href="libs/bootstrap/bootstrap.min.css" rel="stylesheet" />
-    <link href="libs/font-awesome/font-awesome.min.css" rel="stylesheet" />
-    <link href="content/themes/united/bootstrap-theme.min.css" rel="stylesheet" />
+    <link href="content/bootstrap/bootstrap.min.css" rel="stylesheet" />
+    <link href="content/font-awesome/font-awesome.min.css" rel="stylesheet" />
+    <link href="content/bootstrap-theme.min.css" rel="stylesheet" />
     <link href="content/bootstrap-custom.css" rel="stylesheet" />
 
 </head>
@@ -62,18 +62,18 @@
                     </div>
                     <div class="col-lg-8 col-md-7 col-sm-12 col-xs-12">
                         <p class="lead text-justify">
-                            Threat Dragon is an open-source threat modelling tool from OWASP. It comes as an <a href="https://electron.atom.io/" target="_blank">Electron</a> based
-                            installable desktop app for OSX and Windows (Linux coming soon) or a web application. The desktop app saves your threat models on your local file system,
-                            but the online version stores its files in GitHub. This means that to use web app you have to sign in with a GitHub account and give it write access
-                            to your public repos. Other than that, the user experience is currently almost identical between the web and desktop variants. In the future, there will be deeper
-                            integration with GitHub (and other code repositories).
+                            Threat Dragon is an open-source threat modelling tool from OWASP. It comes as a web application or an <a href="https://electron.atom.io/" target="_blank">Electron</a>
+                            based installable desktop app for MacOS, Windows and Linux. The desktop app saves your threat models on your local file system,
+                            but the online version stores its files in GitHub. This means that to use web app you have to sign in with a GitHub account and
+                            give it write access to your public repos. Other than that, the user experience is currently almost identical between the web and
+                            desktop variants. In the future, there will be deeper integration with GitHub (and other code repositories).
                         </p>
                         <p>
-                            Threat Dragon is currently in the early stages of development (an OWASP incubator project) so there might be some bugs.
+                            Threat Dragon is currently in development as an OWASP incubator project, so there might still be some bugs.
                         </p>
                         </br>
                         <p class="text-right">
-                            <img src="content/images/owasp.svg" alt="OWASP logo" title="OWASP logo"/>
+                            <a href="https://owasp.org/www-project-threat-dragon/" target="_blank"><img src="content/images/owasp.svg" alt="OWASP logo" title="OWASP project page"/></a>
                         </p>
                     </div>
                 </div>
@@ -145,20 +145,23 @@
             </div>
             <div class="panel-body">
                 <p>
-                The following installable versions are available for download from <a href="https://github.com/mike-goodwin/owasp-threat-dragon-desktop/releases" taget="_blank">GitHub</a>:
+                The following installable versions are available for download from <a href="https://github.com/mike-goodwin/owasp-threat-dragon-desktop/releases" target="_blank">GitHub</a>:
                     <ul>
                         <li>
                             Windows (64 bit)
                         </li>
                         <li>
-                            OSX
+                            MacOS
+                        </li>
+                        <li>
+                            Linux
                         </li>
                     </ul>
                 </p>
 
                 <div class="alert alert-info" role="alert">
                     <span class="fa fa-flask"></span> The current  versions of the desktop application are not code-signed. This means you could get a warning when you try to install it on Windows. It also
-                    means that the application will not auto-update on OSX. This will be fixed in a future release.
+                    means that the application will not auto-update on any of the platforms. This will be fixed in a future release.
                 </div>
 
             </div>
@@ -298,6 +301,33 @@
                 <p>
                     You will then be able to find the model file in your local file system and open it.
                 </p>
+                <p>
+                    This should give you some ideas on how to get started with your own model. This works for both the web and desktop variants.
+                </p>
+                <hr>
+                <h3>Threat model report</h3>
+                <p>
+                    From the Threat Model details view you can see a summary report of your model listing the diagrams, elements and threats.
+                    Towards the bottom right of the page click
+                </p>
+                <p>
+                    <div>
+                        <a class="btn btn-default"" 
+                        role="button" data-toggle="tooltip" data-placement="top" title="View Or Print Threat Model Report">
+                            <span class="fa fa-file-text"></span> Report
+                        </a>
+                    </div>
+                </p>
+                <p>
+                    You can customise the report to show or hide
+                    <ul>
+                        <li>Out of scope model elements</li>
+                        <li>Mitigated threats</li>
+                        <li>Threat model diagrams</li>
+                    </ul>
+                    On the desktop variant of Threat Dragon you can print the report or save it as a PDF.
+                    On the web variant, you can print the report and then, on most browsers, the print dialog allows you to save the report as a PDF.
+                </p>
             </div>
         </div>
     </div>
@@ -383,18 +413,23 @@
                 The toolbar on the diagram editing page supports some general diagramming features:
                 <hr>
                 <p>
+                <button type="button" class="btn btn-default" uib-btn-checkbox data-toggle="tooltip" data-placement="top" title="Toggle Gridlines">
+                    <span class="glyphicon glyphicon-th" aria-hidden="true"></span>
+                </button> Toggles gridlines on/off. When gridlines are on, elements snap to them for neater models.
+                </p>
+                <p>
                 <a class="btn btn-default" role="button" data-toggle="tooltip" data-placement="top" title="Cancel Edit">
                     <span class="glyphicon glyphicon-remove"></span>
                 </a> Cancels the edit and returns to the threat model details view.
                 </p>
-                <p>
+                <!-- p>
                 <button class="btn btn-default" type="button" data-toggle="tooltip" data-placement="top" title="Zoom in">
                     <span class="glyphicon glyphicon-zoom-in" aria-hidden="true"></span>
                 </button>
                 <button class="btn btn-default" type="button" data-toggle="tooltip" data-placement="top" title="Zoom out">
                     <span class="glyphicon glyphicon-zoom-out" aria-hidden="true"></span>
                 </button> Zooms the diagram in and out.
-                </p>
+                </p -->
                 <p>
                 <button class="btn btn-default" type="button" data-toggle="tooltip" data-placement="top" title="Delete All Elements From This Diagram">
                     <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
@@ -410,10 +445,15 @@
                     <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
                 </button> Generates threats for the selected element using the threat generation rule engine.
                 </p>
-                <div class="alert alert-info" role="alert">
+                <!-- div class="alert alert-info" role="alert">
                     <span class="fa fa-flask"></span> In the current alpha version of OWASP Threat Dragon, the threat generation rule engine is a stub, but you can still manually 
                     add threats to create a full threat model.
-                </div>
+                </div -->
+                <p>
+                <button class="btn btn-default" type="button" data-toggle="tooltip" data-placement="top" title="Duplicate the selected element">
+                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
+                </button> Duplicates the selected element as a new element.
+                </p>
                 <p>
                 <button class="btn btn-default" ng-disabled="!vm.dirty" type="button" data-toggle="tooltip" ng-click="vm.save()" data-placement="top" title="Save This Diagram">
                     <span class="glyphicon glyphicon-save" aria-hidden="true"></span>
@@ -439,7 +479,7 @@
                     </div>
                 </p>
                 Enter the details for your threat in the threat dialog. The <strong>Title</strong> and <strong>STRIDE Threat Type</strong>
-                are mandatory. When you are done, hit <strong>Save</strong>. Your new threat should appear. To edit it again, tap or click
+                are mandatory. When you are done, hit <strong>Save</strong> and your new threat should appear. To edit it again, tap or click
                 its title.
             </div>
         </div>
@@ -448,21 +488,20 @@
     <div class="container-fluid">
         <div class="panel panel-default" id="threat-generation">
             <div class="panel-heading panel-title">
-                <h2><span class="fa fa-flask"></span> Threat generation rules <span class="glyphicon glyphicon-flash fa-lg text-primary pull-right"></span></h2>
+                <h2>Threat generation rules <span class="glyphicon glyphicon-flash fa-lg text-primary pull-right"></span></h2>
             </div>
             <div class="panel-body">
                 <p>
-                Threat Dragon is still working towards its first milestone - an alpha release. At this point, the threat generation rules so far are just a stub to prove the technical approach. A more fully functional rule set
-                is planned for the beta release (milestone 2), as described in the <a href="https://www.owasp.org/index.php/OWASP_Threat_Dragon#Roadmap" target="_blank"> roadmap</a>.
-                
-                Threat Dragon's alpha release aims to provide a basic threat modelling experience, but for the time being, you are on your own in terms of identifying threats and mitigations. 
+                Threat Dragon provides <a href="https://www.microsoft.com/security/blog/2007/10/29/the-stride-per-element-chart/" target="_blank"> STRIDE per Element</a>
+                rules to generate the suggested threats for an element on the diagram - except for trust boundaries. The suggested threats
+                can be individually accepted or ignored, and other threats added manually. 
                 </p>
             </div>
         </div>
     </div>
     
-    <script src="libs/jquery/jquery.min.js"></script>
-    <script src="libs/bootstrap/bootstrap.min.js"></script>
+    <!-- <script src="libs/jquery/jquery.min.js"></script>
+    <script src="libs/bootstrap/bootstrap.min.js"></script> -->
 
 </body>
 </html>


### PR DESCRIPTION
This updates the gh-pages branch, which will then update the docs at : 
http://docs.threatdragon.org/

The changes are mainly: 
* add reference to Linux desktop version
* add the existing STRIDE per Element rules
* remove reference to zoom, until zoom is reinstated